### PR TITLE
Panic occurs in time.go

### DIFF
--- a/time.go
+++ b/time.go
@@ -102,6 +102,10 @@ func tnType(r rune) int {
 }
 
 func timeStep(r rune, cur *timeNode) *timeNode {
+	if cur == nil {
+		return nil
+	}
+
 	t := tnType(r)
 
 	for _, n := range cur.children {


### PR DESCRIPTION
I get : 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x4cf023]

goroutine 1 [running]:
github.com/trustpath/sequence.timeStep(0xc80000005b, 0x0, 0x5b)
        /home/miramaze/go/src/github.com/trustpath/sequence/time.go:107 +0xa3
github.com/trustpath/sequence.(*Message).scanToken(0xc820063ba0, 0xc8200b2000, 0x26da, 0x0, 0x12, 0x0, 0x0)
        /home/miramaze/go/src/github.com/trustpath/sequence/message.go:177 +0x213
github.com/trustpath/sequence.(*Message).Tokenize(0xc820063ba0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/miramaze/go/src/github.com/trustpath/sequence/message.go:95 +0x31c
github.com/trustpath/sequence.(*Scanner).Scan(0xc82000e6e0, 0xc8200b2000, 0x26da, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/miramaze/go/src/github.com/trustpath/sequence/scanner.go:134 +0xd7
github.com/antham/goller/tokenizer.Tokenize(0xc8200b2000, 0x26da, 0x0, 0x0, 0x0)
        /home/miramaze/go/src/github.com/antham/goller/tokenizer/tokenizer.go:17 +0x63
main.count.func1(0xc8200b2000, 0x26da)
        /home/miramaze/go/src/github.com/antham/goller/main.go:34 +0x6a
github.com/antham/goller/reader.ReadStdin(0xc82004dd58)
        /home/miramaze/go/src/github.com/antham/goller/reader/reader.go:11 +0x172
main.count(0x7fff6fc0263f, 0x1, 0x6ae810, 0x3)
        /home/miramaze/go/src/github.com/antham/goller/main.go:45 +0x1db
main.main()
        /home/miramaze/go/src/github.com/antham/goller/main.go:24 +0x187

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
        /usr/lib/go/src/runtime/asm_amd64.s:1721 +0x1
exit status 2
```

when trying to parse this entry : 

`[2014-10-04 17:06] [PACMAN] Running 'pacman -S --noconfirm a52dec aalib abiword ack acl acpi aircrack-ng alsa-lib alsa-oss alsa-utils android-tools android-udev apache-ant apr apr-util aqbanking archlinux-keyring arpack aspell at-spi2-atk at-spi2-core ati-dri atk atkmm attica attr audacity audiofile autoconf automake avahi avidemux-cli babl barrage bash bc binutils bison bitcoin-qt blas bluez-libs bochs bogofilter boost boost-libs bridge-utils bzip2 ca-certificates ca-certificates-java cabextract cairo cairo-perl cairomm cddb_get cdparanoia cdrdao cdrkit celt celt0.5.1 chmlib chromium cifs-utils cloog clucene cmake colord compositeproto confuse convmv coreutils cpio cpupower cracklib cryptsetup cscope ctags curl customizepkg cvs damageproto dash db dbus dbus-glib dcfldd dconf ddrescue desktop-file-utils device-mapper dhclient dhcpcd dialog diffutils dirmngr djvulibre dkms dmenu dmidecode dmxproto dnsmasq dnssec-anchors dnsutils docbook-xml docbook-xsl docker dosfstools dotconf dri2proto dsniff dvd+rw-tools e2fsprogs easytag ed elfutils elinks emacs emacs-w3m-cvs enca enchant ethtool eventlog exiv2 exo expat ext4magic extundelete faac faad2 fabric fakeroot fastjar fdupes ffmpeg ffmpeg-compat fftw file filesystem filezilla findutils firefox fixesproto flac flashplugin fluidsynth fontconfig fontsproto fox fprintd freeglut freetype2 frei0r-plugins fribidi fswebcam fuse gamin gavl gawk gc gcc-libs-multilib gcc-multilib gconf gd gdb gdbm gdk-pixbuf2 gegl geoclue2 gettext ghostscript giblib giflib gimp git gksu glade-perl glib-networking glib-perl glib2 glibc glibmm glproto glu gmp gnome-doc-utils gnome-mime-data gnucash gnupg gnutls gobject-introspection gocr goffice goffice0.8 gpart gparted gpgme gpm grantlee graphite graphviz grep groff grub gsettings-desktop-schemas gsfonts gsl gsm gst-libav gst-plugins-base gst-plugins-base-libs gst-plugins-good gstreamer gstreamer0.10 gstreamer0.10-bad gstreamer0.10-base gstreamer0.10-base-plugins gstreamer0.10-ffmpeg gstreamer0.10-good gstreamer0.10-good-plugins gtk-update-icon-cache gtk2 gtk2-perl gtk3 gtkglext gtkmm gtksourceview2 gtksourceview3 gtkspell gts guile guile1.8 gvfs gwenhywfar gzip harfbuzz harfbuzz-icu hicolor-icon-theme hspell htop hunspell hwids hwloc hyphen iana-etc icedtea-web icu id3lib id3v2 idnkit ilmbase imagemagick imlib2 inetutils iniparser inputproto intel-dri intel-tbb intltool iproute2 iptables iputils isl iw jack jansson jasper java-common jdk7-openjdk jfsutils jre7-openjdk jre7-openjdk-headless js js17 js185 jshon json-c json-glib julia kbd kbproto kdelibs keyutils kmod krb5 ktoblzcheck ladspa lame lapack lcms lcms2 ldb ldns less lesstif lib32-alsa-lib lib32-attr lib32-bzip2 lib32-curl lib32-e2fsprogs lib32-elfutils lib32-expat lib32-flac lib32-fontconfig lib32-freetype2 lib32-gcc-libs lib32-glib2 lib32-glibc lib32-harfbuzz lib32-icu lib32-json-c lib32-keyutils lib32-krb5 lib32-lcms2 lib32-libasyncns lib32-libcap lib32-libdbus lib32-libdrm lib32-libffi lib32-libgcrypt lib32-libgpg-error lib32-libice lib32-libjpeg-turbo lib32-libldap lib32-libmng lib32-libogg lib32-libpciaccess lib32-libpng lib32-libpulse lib32-libsm lib32-libsndfile lib32-libssh2 lib32-libstdc++5 lib32-libtiff lib32-libvorbis lib32-libx11 lib32-libxau lib32-libxcb lib32-libxcursor lib32-libxdamage lib32-libxdmcp lib32-libxext lib32-libxfixes lib32-libxi lib32-libxrandr lib32-libxrender lib32-libxshmfence lib32-libxss lib32-libxtst lib32-libxv lib32-libxxf86vm lib32-llvm-libs lib32-mesa lib32-mesa-libgl lib32-ncurses lib32-openal lib32-openssl lib32-pcre lib32-qt4 lib32-sdl lib32-sqlite lib32-systemd lib32-util-linux lib32-v4l-utils lib32-wayland lib32-xz lib32-zlib libaio libao libarchive libart-lgpl libass libassuan libasyncns libatasmart libatomic_ops libavc1394 libbluray libbonobo libbsd libburn libcaca libcacard libcanberra libcap libcap-ng libcdaudio libcddb libcdio libcdio-paranoia libcl libcroco libcryptoplus libcups libdaemon libdatrie libdbi libdbi-drivers libdbus libdbusmenu-qt libdc1394 libdca libdmx libdrm libdv libdvbpsi libdvdnav libdvdread libebml libedit libepoxy libevdev libevent libexif libffi libfontenc libftdi libftdi-compat libgcrypt libgksu libglade libgme libgnome-data libgnome-keyring libgnomecanvas libgpg-error libgsf libgtop libgusb libical libice libid3tag libidl2 libidn libiec61883 libimobiledevice libirman libiscsi libisofs libjpeg-turbo libkate libksba libldap liblqr liblrdf libltdl libmad libmatroska libmikmod libmm-glib libmms libmng libmodplug libmp3splt libmp4v2 libmpc libmpcdec libmpeg2 libmtp libnet libnewt libnice libnids libnl libnm-glib libofa libofx libogg libomxil-bellagio libotf libpaper libpcap libpciaccess libpipeline libplist libpng libpng12 libproxy libpulse libquvi libquvi-scripts libqzeitgeist libraw1394 libreoffice-still-af libreoffice-still-common libreoffice-still-fr libreoffice-still-writer librsvg libsamplerate libsasl libseccomp libsecret libshout libsidplay libsigc++ libsigsegv libsm libsndfile libsodium libsoup libspectre libspiro libssh2 libstdc++5 libsystemd libtar libtasn1 libthai libtheora libtiff libtiger libtirpc libtool libtxc_dxtn libunicodenames libunique libunistring libunwind libupnp libusb libusb-compat libusbmuxd libutempter libutil-linux libva libvdpau libvisual libvorbis libvpx libwbclient libwebp libwmf libx11 libx264 libx86 libxau libxaw libxcb libxcomposite libxcursor libxdamage libxdmcp libxext libxfce4ui libxfce4util libxfixes libxfont libxft libxi libxinerama libxkbcommon libxkbcommon-x11 libxkbfile libxkbui libxml++ libxml2 libxmu libxp libxpm libxrandr libxrender libxshmfence libxslt libxss libxt libxtst libxv libxvmc libxxf86dga libxxf86vm libyaml licenses lighttpd linux linux-api-headers linux-atm linux-firmware linux-headers lirc-utils llvm-libs logrotate lsb-release lua lua-bitop lua-expat lua-socket lua51 lvm2 lynx lzo m17n-db m17n-lib m4 make man-db man-pages mc mcpp mdadm media-player-info meld mercurial mesa mesa-libgl mime-types miniupnpc mirage mjpegtools mkinitcpio mkinitcpio-busybox mlocate mlt mosh mozilla-common mp3gain mp3info mp3splt mpfr mpg123 mtdev mtools mutt ncurses neon net-tools netpbm nettle ngrep nmap nodejs nspr nss ntfs-3g openal opencore-amr opencv openexr openjpeg openmpi openntpd openslp opensp openssh openssl openvpn opus opusfile orbit2 orc p11-kit p7zip package-query pacman pacman-mirrorlist pam pambase pango pango-perl pangomm pangox-compat parted partimage patch pciutils pcmciautils pcre perl perl-anyevent perl-async-interrupt perl-common-sense perl-error perl-ev perl-event-execflow perl-file-next perl-file-which perl-getopt-argvfile perl-gtk2-ex-formfactory perl-guard perl-io-tty perl-json-xs perl-libintl-perl perl-mp3-info perl-net-ssleay perl-rename perl-types-serialiser perl-xml-parser phantomjs phonon-qt4 phonon-qt4-gstreamer pinentry pixman pkg-config polkit polkit-qt4 poppler poppler-qt4 popt portaudio ppp pptpclient printproto privoxy procps-ng progsreiserfs protobuf proxychains-ng psmisc pssh pth pulseaudio pv pygobject-devel pygobject2-devel pygtk pygtksourceview2 pyid3lib python python-dbus python-dbus-common python-setuptools python-urllib3 python-xdg python2 python2-beaker python2-cairo python2-crypto python2-dbus python2-ecdsa python2-gobject python2-gobject2 python2-mako python2-markupsafe python2-paramiko python2-rope python2-setuptools python2-urwid qca qemu qrencode qt4 qtchooser qtwebkit quvi qwt randrproto raptor rarian rasqal readline recode recordproto recoverdm redland reiserfsprogs renderproto rfkill rlwrap rpcbind rsync rtkit rtmpdump rubber ruby ruby-highline ruby-mime-types run-parts rxvt-unicode rxvt-unicode-terminfo s-nail sbc sbcl schroedinger screen scrnsaverproto scrot sdl sdl_image sdl_mixer sdl_ttf seabios sed serf shadow shared-mime-info skype slang slib smpeg snappy sound-theme-freedesktop soundtouch sox spandsp speech-dispatcher speex spice sqlite sshfs startup-notification strace strigi subversion sudo svga-dri swt sysfsutils syslinux syslog-ng systemd systemd-sysvcompat t1lib taglib talloc tar tcpdump tdb testdisk tevent texi2html texinfo texlive-bin texlive-core texlive-latexextra tftp-hpa thin-provisioning-tools thinkfinger tig tinyproxy tmux tor transmission-cli tre ttf-dejavu ttf-freefont tzdata udisks2 unetbootin unixodbc unoconv unrar unzip upower usbredir usbutils util-linux v4l-utils v8 vagrant valgrind vbetool vde2 vi videoproto virtualbox virtualbox-guest-dkms virtualbox-guest-iso virtualbox-guest-modules virtualbox-guest-utils virtualbox-host-modules vlc vte vte-common w3m wavpack wayland webkitgtk webkitgtk2 webrtc-audio-processing wget wgetpaste which whois wicd wildmidi winusb wireless_tools wireshark-cli wireshark-gtk wpa_supplicant wv wxgtk wxgtk2.8 wxpython x264 x265 xbitmaps xcb-proto xcb-util xcb-util-image xcb-util-keysyms xcb-util-wm xclip xdg-utils xextproto xf86-input-evdev xf86-input-mouse xf86-input-synaptics xf86-input-vmmouse xf86-video-ati xf86-video-chips xf86-video-fbdev xf86-video-vesa xf86-video-vmware xf86dgaproto xf86vidmodeproto xfburn xfconf xfe xfsprogs xine-lib xineramaproto xkeyboard-config xorg-bdftopcf xorg-font-util xorg-font-utils xorg-fonts-100dpi xorg-fonts-75dpi xorg-fonts-alias xorg-fonts-cyrillic xorg-fonts-encodings xorg-fonts-misc xorg-iceauth xorg-luit xorg-mkfontdir xorg-mkfontscale xorg-server xorg-server-common xorg-server-utils xorg-sessreg xorg-setxkbmap xorg-smproxy xorg-utils xorg-x11perf xorg-xauth xorg-xbacklight xorg-xcmsdb xorg-xcursorgen xorg-xdm xorg-xdpyinfo xorg-xdriinfo xorg-xev xorg-xgamma xorg-xhost xorg-xinit xorg-xinput xorg-xkb-utils xorg-xkbcomp xorg-xkbevd xorg-xkbutils xorg-xkill xorg-xlsatoms xorg-xlsclients xorg-xmessage xorg-xmodmap xorg-xpr xorg-xprop xorg-xrandr xorg-xrdb xorg-xrefresh xorg-xset xorg-xsetroot xorg-xvinfo xorg-xwd xorg-xwininfo xorg-xwud xproto xsel xterm xtmsplit xulrunner xvidcore xz yajl yaourt youtube-dl yp-tools ypbind-mt zip zita-alsa-pcmi zita-resampler zlib zsh zvbi zziplib'`
